### PR TITLE
fix for missing libpng12-dev + consequences of self-provisioning

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -136,7 +136,7 @@ binary-arch: build install
 #	dh_perl
 #	dh_makeshlibs
 	dh_installdeb
-	dh_shlibdeps
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 	dh_gencontrol
 	dh_md5sums
 	dh_builddeb


### PR DESCRIPTION
I wanted to directly build in an up-to-date vanilla proxmox/stretch system, sorry if this is not a good thing :)

The idea is to replace the step:
//# The dependencies for the Debian QEMU version are a good starting point:
apt-get build-dep qemu -y --force-yes

With:
- installing some deps manually:
	// # apt install -y libjpeg-dev libusb-1.0-0-dev xfslibs-dev libspice-protocol-dev libiscsi-dev librbd-dev libaio-dev uuid-dev texinfo debhelper libgnutls28-dev libsdl1.2-dev libusbredirparser-dev
- compling libpng12 from source (prefix /usr/local)

Then just go on with the instructions at http://www.nicksherlock.com/2017/04/fix-for-macos-sierra-10-12-4-dont-steal-mac-os-error-on-boot-on-proxmox-4-4/

credits! https://github.com/linuxmint/nemo/issues/1079#issuecomment-195934523